### PR TITLE
Add support for custom base urls and model names

### DIFF
--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -46,7 +46,6 @@
   }
 
   let showAdvanced = false;
-  let openaiBaseUrl = "https://api.openai.com/v1";
 </script>
 
 <!-- Hide on escape -->
@@ -195,23 +194,31 @@
           <h3 class="text-xl mb-4 sm:col-span-2">Custom OpenAI Settings</h3>
 
           <label class="label" for="b"> Base URL: </label>
-          <div class:warning={!openaiBaseUrl}>
+          <div>
             <input
               id="b"
               class="input rounded w-full"
               type="text"
               placeholder="https://api.openai.com/v1/"
-              bind:value={openaiBaseUrl}
+              bind:value={$openAiConfig.baseURL}
             />
             <p class="leading-tight">
               <small>
-                You can set a custom OpenAI base url to use Prompta with tools
-                like helicone or local LLMs that have OpenAI compatible APIs (eg <a
+                You can set a custom OpenAI base url to use Prompta with 3rd
+                party tools such as helicone or local LLMs that expose OpenAI
+                compatible APIs like <a
                   href="https://github.com/mudler/LocalAI"
                   class="text-blue-200 hover:underline"
                   target="_blank"
                   rel="noopener noreferrer">LocalAI</a
-                >)
+                >
+                or
+                <a
+                  href="https://github.com/BerriAI/litellm"
+                  class="text-blue-200 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer">LiteLLM</a
+                >.
               </small>
             </p>
           </div>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -31,7 +31,7 @@
 
   const updateAvailableModels = async () => {
     if ($chatModels.length) {
-      console.debug("Already have models, not re-fetching");
+      console.debug("Already have models, but refetching for latest");
     }
 
     const openai = getOpenAi();
@@ -42,15 +42,12 @@
   };
 
   let showAdvanced = false;
-  let customModel = ''
 
   $: if ($showSettings) {
     updateAvailableModels();
   }
 
-  $: if (customModel) {
-    $gptProfileStore.model = customModel;
-  }
+  $: hasCustomModel = !$chatModels.some((x) => x.id == $gptProfileStore.model);
 
   $: if (!$openAiConfig.baseURL) {
     $openAiConfig.baseURL = "https://api.openai.com/v1/";
@@ -140,11 +137,10 @@
               <option value={model.id}>{model.id}</option>
             {/each}
           </select>
-          {#if $gptProfileStore.model === "gpt-4"}
-            <p>
+          {#if hasCustomModel}
+            <p class="border border-yellow-400 mt-2 rounded bg-yellow-500/20">
               <small
-                >Warning: gpt-4 may require an invite. If chat doesn't work make sure your account
-                has an invite by checking your email.</small
+                ><strong>WARNING:</strong> Using custom model. See "Advanced" settings below.</small
               >
             </p>
           {/if}
@@ -202,10 +198,10 @@
 
           <h3 class="text-xl mb-4 sm:col-span-2">Custom OpenAI Settings</h3>
 
-          <label class="label" for="b"> Base URL: </label>
+          <label class="label" for="baseUrl"> Base URL: </label>
           <div>
             <input
-              id="b"
+              id="baseUrl"
               class="input rounded w-full"
               type="text"
               placeholder="https://api.openai.com/v1/"
@@ -213,9 +209,8 @@
             />
             <p class="leading-tight">
               <small>
-                You can set a custom OpenAI base url to use Prompta with 3rd
-                party tools such as helicone or local LLMs that expose OpenAI
-                compatible APIs like <a
+                You can set a custom OpenAI base url to use Prompta with 3rd party tools such as
+                helicone or local LLMs that expose OpenAI compatible APIs like <a
                   href="https://github.com/mudler/LocalAI"
                   class="text-blue-200 hover:underline"
                   target="_blank"
@@ -232,18 +227,19 @@
             </p>
           </div>
 
-          <label class="label" for="c"> Custom Model: </label>
+          <label class="label" for="customModel"> Custom Model: </label>
           <div>
             <input
-              id="c"
+              id="customModel"
               class="input rounded w-full"
               type="text"
               placeholder="Enter custom model name"
-              bind:value={customModel}
+              bind:value={$gptProfileStore.model}
             />
             <p class="leading-tight">
               <small>
-                You can set a custom OpenAI model to use with Prompta. This will override the model choice above.
+                You can set a custom OpenAI model to use with Prompta. This will override the model
+                choice above.
               </small>
             </p>
           </div>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -52,6 +52,9 @@
     $gptProfileStore.model = customModel;
   }
 
+  $: if (!$openAiConfig.baseURL) {
+    $openAiConfig.baseURL = "https://api.openai.com/v1/";
+  }
 </script>
 
 <!-- Hide on escape -->

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -253,7 +253,7 @@
                     `Are you sure you want to import ${file.name}? Although unlikely, this can cause data loss if you are importing two exports from the same database.`
                   ))
                 ) {
-                  console.log("Canclled");
+                  console.log("Cancelled");
                   return;
                 }
 

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -41,11 +41,18 @@
       .sort((a, b) => a.id.localeCompare(b.id));
   };
 
+  let showAdvanced = false;
+  let customModel = ''
+
   $: if ($showSettings) {
     updateAvailableModels();
   }
 
-  let showAdvanced = false;
+
+  $: if (customModel) {
+    $gptProfileStore.model = customModel;
+  }
+
 </script>
 
 <!-- Hide on escape -->
@@ -219,6 +226,22 @@
                   target="_blank"
                   rel="noopener noreferrer">LiteLLM</a
                 >.
+              </small>
+            </p>
+          </div>
+
+          <label class="label" for="c"> Custom Model: </label>
+          <div>
+            <input
+              id="c"
+              class="input rounded w-full"
+              type="text"
+              placeholder="Enter custom model name"
+              bind:value={customModel}
+            />
+            <p class="leading-tight">
+              <small>
+                You can set a custom OpenAI model to use with Prompta. This will override the model choice above.
               </small>
             </p>
           </div>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -46,6 +46,7 @@
   }
 
   let showAdvanced = false;
+  let openaiBaseUrl = "https://api.openai.com/v1";
 </script>
 
 <!-- Hide on escape -->
@@ -190,6 +191,31 @@
         </button>
         {#if showAdvanced}
           <!-- separator -->
+
+          <h3 class="text-xl mb-4 sm:col-span-2">Custom OpenAI Settings</h3>
+
+          <label class="label" for="b"> Base URL: </label>
+          <div class:warning={!openaiBaseUrl}>
+            <input
+              id="b"
+              class="input rounded w-full"
+              type="text"
+              placeholder="https://api.openai.com/v1/"
+              bind:value={openaiBaseUrl}
+            />
+            <p class="leading-tight">
+              <small>
+                You can set a custom OpenAI base url to use Prompta with tools
+                like helicone or local LLMs that have OpenAI compatible APIs (eg <a
+                  href="https://github.com/mudler/LocalAI"
+                  class="text-blue-200 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer">LocalAI</a
+                >)
+              </small>
+            </p>
+          </div>
+
           <h3 class="text-xl mb-4 sm:col-span-2">Database</h3>
 
           <label for="export" class="label">Export:</label>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -48,7 +48,6 @@
     updateAvailableModels();
   }
 
-
   $: if (customModel) {
     $gptProfileStore.model = customModel;
   }

--- a/src/lib/llm/openai.ts
+++ b/src/lib/llm/openai.ts
@@ -1,18 +1,17 @@
-import { OpenAI } from "openai";
+import { OpenAI, type ClientOptions } from "openai";
 
 let openai: OpenAI;
 
-export const initOpenAi = ({ apiKey = "" }: { apiKey: string }) => {
+export const initOpenAi = (opts: ClientOptions) => {
   if (openai) {
     return openai;
   }
 
   openai = new OpenAI({
-    apiKey,
-
     // The app is currently all browser-based, and the key is stored locally and
     // only sent to openai.
     dangerouslyAllowBrowser: true,
+    ...opts,
   });
 
   return openai;

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -83,6 +83,7 @@ export const openAiConfig = (() => {
     replicationHost: "",
     siteId: "",
     lastSyncChain: "",
+    baseURL: 'https://api.openai.com/v1/'
   };
 
   const { subscribe, set, update } = writable<OpenAiAppConfig>(defaultConfig);
@@ -230,7 +231,7 @@ Do not provide a word count or add quotation marks.
   };
 
   // Generate a thread title
-  const baseURL = get(openAiConfig)?.baseURL || '';
+  const baseURL = get(openAiConfig)?.baseURL || 'https://api.openai.com/v1/';
   const res = await fetch(`${baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL}/chat/completions`, {
     method: 'POST',
     headers: {

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -184,6 +184,14 @@ export const getOpenAi = () => {
 };
 
 export const verifyOpenAiApiKey = async (apiKey: string) => {
+  const conf = get(openAiConfig);
+  const baseURL = conf.baseURL as string;
+
+  // Skip verification if the base url is not the standard openai base url
+  if (baseURL && baseURL !== 'https://api.openai.com/v1/') {
+    return true;
+  }
+
   try {
     const res = await fetch("https://api.openai.com/v1/models", {
       headers: {

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -204,7 +204,7 @@ export const generateThreadTitle = async ({ threadId }: { threadId: string }) =>
   const messageContext = context.map((x) => ({ content: x.content, role: x.role }));
 
   const prompt: OpenAI.Chat.CompletionCreateParamsNonStreaming = {
-    model: "gpt-3.5-turbo", // @note Using the cheaper and faster model for title generation
+    model: get(gptProfileStore)?.model || "gpt-3.5-turbo", // Use custom model if present, else use turbo 3.5
     temperature: 0.2, // Playing around with this value the lower value seems to be more accurate?
     messages: [
       ...messageContext,

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -212,6 +212,7 @@ export const generateThreadTitle = async ({ threadId }: { threadId: string }) =>
   const messageContext = context.map((x) => ({ content: x.content, role: x.role }));
 
   const prompt: OpenAI.Chat.CompletionCreateParamsNonStreaming = {
+   // @note Using the cheaper and faster model for title generation
     model: get(gptProfileStore)?.model || "gpt-3.5-turbo", // Use custom model if present, else use turbo 3.5
     temperature: 0.2, // Playing around with this value the lower value seems to be more accurate?
     messages: [

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -221,7 +221,15 @@ Do not provide a word count or add quotation marks.
   };
 
   // Generate a thread title
-  const res = await openAi.chat.completions.create(prompt);
+  const baseURL = get(openAiConfig)?.baseURL || '';
+  const res = await fetch(`${baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${get(openAiConfig).apiKey}`
+    },
+    body: JSON.stringify(prompt)
+  }).then(response => response.json());
 
   let newTitle = res.choices[0].message?.content || "Untitled";
 
@@ -599,7 +607,7 @@ export const currentChatThread = (() => {
     abortController = new AbortController();
 
     // @todo This could use the sdk now that the new version supports streaming
-    await fetchEventSource("https://api.openai.com/v1/chat/completions", {
+    await fetchEventSource(`${conf?.baseURL?.endsWith('/') ? conf.baseURL.slice(0, -1) : conf.baseURL}/chat/completions`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${conf.apiKey}`,


### PR DESCRIPTION
This makes it possible to use Prompta as a client with local LLMs. 

One way to do this is to use [Ollama](https://ollama.ai/) together with [LiteLLM](https://litellm.ai/). For example:

```bash
# (run each command in a separate terminal)
ollama serve
ollama pull llama2-uncensored
litellm --api_base http://localhost:11434
```

You can then set the base url in Prompta's settings to `http://<your-ollama-ip>:8000/v1`, set the model name to `ollama/llama2-uncensored` and chat with llama2-uncensored using Prompta.

---

via #12 