### PR TITLE
Some quality of life improvements when working with non-openai base urls

### DIFF
--- a/src/lib/components/InitScreen.svelte
+++ b/src/lib/components/InitScreen.svelte
@@ -76,7 +76,7 @@
     out:fly={{ duration: 300, delay: 0, y: 50, opacity: 0 }}
     class="mt-8 max-w-[400px] flex flex-col space-y-4"
   >
-    <label for="sk"> OpenAi API Key </label>
+    <label for="sk"> OpenAI API Key </label>
     <div
       class={classNames("rounded p-px gradient-border", {
         error: error,

--- a/src/lib/components/InitScreen.svelte
+++ b/src/lib/components/InitScreen.svelte
@@ -44,6 +44,10 @@
       loading = false;
     }
   };
+
+  const skipInitScreen = () => {
+    $showInitScreen = false;
+  };
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -117,6 +121,13 @@
       </small>
     </p>
   </form>
+  <div
+    on:click={skipInitScreen}
+    class="fixed top-2 right-2 text-center text-white font-semibold tracking-wide cursor-pointer"
+    title="Skip"
+  >
+    &#10005;
+  </div>
 </div>
 
 <style>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -47,7 +47,9 @@
     updateAvailableModels();
   }
 
-  $: hasCustomModel = !$chatModels.some((x) => x.id == $gptProfileStore.model);
+  $: hasCustomModel =
+    $gptProfileStore.model &&
+    !$chatModels.some((x) => x.id == $gptProfileStore.model);
 
   $: if (!$openAiConfig.baseURL) {
     $openAiConfig.baseURL = "https://api.openai.com/v1/";

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -37,7 +37,7 @@
     const openai = getOpenAi();
     const xs = await openai.models.list();
     $chatModels = xs.data
-      .filter((x) => x.id.startsWith("gpt"))
+      .filter((x) => $openAiConfig.baseURL?.startsWith("https://api.openai.com/v1") ? x.id.startsWith("gpt") : true)
       .sort((a, b) => a.id.localeCompare(b.id));
   };
 

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -54,6 +54,12 @@
   $: if (!$openAiConfig.baseURL) {
     $openAiConfig.baseURL = "https://api.openai.com/v1/";
   }
+
+  $: {
+    if ($openAiConfig.baseURL || $openAiConfig.apiKey) {
+      updateAvailableModels();
+    }
+  }
 </script>
 
 <!-- Hide on escape -->


### PR DESCRIPTION
Specifically:

- Allow skipping the init screen (so that you can start the app without needing a valid OpenAI API key)
- Update the model list when base url or api key is changed so you can easily browse the model lists offered by non-openai base urls