### PR TITLE
Fixed link, typo, and phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Yet another interface for chatting with ChatGPT (or GPT-4).
 
 [Website](https://www.prompta.dev)
-| [Downloads](releases)
+| [Downloads](https://github.com/iansinnott/prompta/releases)
 | [Launch App](https://chat.prompta.dev)
 
 </div>
@@ -42,8 +42,8 @@ Yet another interface for chatting with ChatGPT (or GPT-4).
 
 ## How to use
 
-- Use in your web browser: [chat.prompta.dev](https://chat.prompta.dev)
-- Download the desktop app: Download the latest build from the [releases page](releases)
+- In your web browser: [chat.prompta.dev](https://chat.prompta.dev)
+- Desktop app: download the latest build from [the releases page](https://github.com/iansinnott/prompta/releases)
 
 ### Running on macOS
 


### PR DESCRIPTION
Relative link does not play well with README.md:

```markdown
[releases page](releases) -> https://github.com/iansinnott/prompta/blob/master/releases -> 404 
```

Also there here looks like two sentences were merged:
```markdown
Download the desktop app: Download the latest build from the
```