### PR TITLE
fix 'Back to chat' showing on first start in tauri

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -309,7 +309,7 @@
       "bottom-[14px]": !sys.isPWAInstalled,
     })}
   >
-    {#if $page.url.pathname !== "/"}
+    {#if $page?.url?.pathname && $page.url.pathname !== "/"}
       <a in:fly={{ duration: 150, delay: 200, x: 20 }} href="/" class="flex items-center space-x-2">
         <ChevronLeftCircle class="w-6 h-6" /> <span>Back to chat</span>
       </a>


### PR DESCRIPTION
`$page.url.pathname` is an empty string when building in tauri with `pnpm build`, which was causing the "Back to chat" text to appear over the send button as show below (oddly when running in tauri with `pnpm dev:tauri` `$page.url.pathname` is set normally so this doesn't happen)

![image](https://github.com/user-attachments/assets/366bc39a-419d-4b15-9c20-e146970aeb39)