### PR TITLE
Make sync server endpoints path-relative

### DIFF
--- a/src/lib/stores/stores/index.ts
+++ b/src/lib/stores/stores/index.ts
@@ -722,7 +722,7 @@ export const syncStore = (() => {
 
   const healthcheck = async () => {
     const endpoint = get(serverConfig).endpoint;
-    const u = new URL("/health", endpoint);
+    const u = new URL("./health", endpoint);
     const res = await fetch(u).then((x) => (x.ok ? x.json() : Promise.reject(x)));
 
     if (res.status === "ok" && res.n === 47) {
@@ -767,7 +767,7 @@ export const syncStore = (() => {
 
   const registerSchema = async (schemaName: string, content: string) => {
     const endpoint = get(serverConfig).endpoint;
-    const u = new URL("/schema", endpoint);
+    const u = new URL("./schema", endpoint);
     const res = await fetch(u, {
       method: "POST",
       body: JSON.stringify({ schemaName, content }),
@@ -838,7 +838,7 @@ export const syncStore = (() => {
 
       console.debug("register schema ::", schema_name, result);
 
-      const syncEndpoint = new URL("/changes", get(serverConfig).endpoint).href;
+      const syncEndpoint = new URL("./changes", get(serverConfig).endpoint).href;
       syncAdapter = await createSyncer({
         db: _db,
         endpoint: syncEndpoint,


### PR DESCRIPTION
This backwards-compatible change allows the sync server endpoint to include a path, e.g. https://example.com/syncserver/, and facilitates serving the Prompta app and sync server from the same host.

(I am using this with a Dockerfile that runs an nginx server to serve the statically-built app, and to reverse-proxy requests from /db/ to a locally-running sync server, all wrapped up with the s6 supervisor to launch and keep everything running; can share this in a separate pull request).