### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY . .
 
 # Use Bun instead of PNPM for package management
 RUN bun install --frozen-lockfile
+RUN bun pm trust --all
 RUN bun run build:server
 
 FROM node:20-slim as dist


### PR DESCRIPTION
With bun, `bun pm trust --all` is needed to ensure postinstall scripts for modules like @vlcn.io/crsqlite are run (and, in this case, the needed crsqlite.so library built).
