### PR TITLE
Integrated Client/Server image Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,139 @@
-FROM node:20 as builder
+# syntax=docker/dockerfile:1.3-labs
+
+FROM node:20-slim as builder
+
+ARG TELEMETRY=1
+
+# Set sensible shell
+SHELL ["/bin/bash", "-e", "-c"]
+
+# Install needed debian packages
+RUN <<EOF
+apt-get update
+DEBIAN_FRONTEND=noninteractive
+apt-get install -y curl 
+apt-get install -y --no-install-recommends pkg-config build-essential s6 nginx unzip
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+EOF
+
+# Install app
+ENV HOME=/home/prompta
+ENV APP=$HOME/app
+ENV SYNC_SERVER_PATH=/db/
+ENV DATA=/data
+
+# Create entrypoint, prompta user, and key directories
+RUN <<EOF
+cat <<EOT >/entrypoint.sh
+#!/bin/bash
+exec /usr/bin/s6-svscan $HOME/s6
+EOT
+
+useradd --home-dir $HOME --shell /bin/bash prompta
+mkdir -p $APP $DATA
+chown -R prompta:prompta $HOME $DATA /entrypoint.sh
+chmod 755 /entrypoint.sh
+EOF
+
+# Do the rest as prompta user, in the app dir
+USER prompta
+WORKDIR $APP
 
 # Install Bun
 RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+ENV PATH="$HOME/.bun/bin:${PATH}"
 
-RUN apt-get update; apt install -y python-is-python3 pkg-config build-essential
-RUN mkdir /app
-WORKDIR /app
+# Copy in the code
+COPY --chown=prompta:prompta . .
 
-COPY . .
+# Make client app's default sync-server URI relative to URI on which it's hosted
+RUN sed -r -i.bak "s|return.*https://prompta-production.up.railway.app.*$|return window.location.href.replace(/(https?:\\\/\\\/[^\\\/]+)(\\\/.*)?$/, \"\$1$SYNC_SERVER_PATH\");|" src/lib/sync/vlcn.ts
 
-# Use Bun instead of PNPM for package management
-RUN bun install --frozen-lockfile
-RUN bun pm trust --all
+# Disable telemetry
+RUN [ "$TELEMETRY" = 0 ] && sed -r -i.bak 's!(cap\(|window.posthog.capture\()!return; // &!' src/lib/capture.ts
+
+# # Use Bun instead of PNPM for package management
+RUN bun install --frozen-lockfile && \
+    bun pm trust --all
+
+# Build static client
+RUN bun run ui:build-static
+
+# Compile db server typescript
 RUN bun run build:server
 
-FROM node:20-slim as dist
+# Create s6 runscripts
+WORKDIR $HOME
 
-COPY --from=builder /app /app
-WORKDIR /app
-ENV NODE_ENV production
-ENV PORT 8080
-CMD [ "node", "./dist-server/server.js" ]
+RUN <<EOF
+mkdir -p s6/db s6/www
+
+cat <<EOT >$HOME/s6/www/run
+#!/bin/bash
+
+exec /usr/sbin/nginx -c $APP/nginx.conf -g 'daemon off;'
+EOT
+
+cat <<EOT >$HOME/s6/db/run
+#!/bin/bash
+
+cd $APP
+export PORT=8081
+export HOST=127.0.0.1
+export BODYLIMIT=100
+export RAILWAY_VOLUME_MOUNT_PATH="$DATA"
+exec node ./dist-server/server.js
+EOT
+
+chmod 755 $HOME/s6/*/run
+
+cat <<'EOT' >$APP/nginx.conf
+
+pid /tmp/nginx.pid;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    client_body_temp_path /tmp;
+    proxy_temp_path /tmp;
+    fastcgi_temp_path /tmp;
+    uwsgi_temp_path /tmp;
+    scgi_temp_path /tmp;
+    access_log /dev/stdout;
+    error_log /dev/stderr;
+
+    server {
+        listen 8080;
+
+        location / {
+            root APP/build;
+            index index.html;
+        }
+
+        location ~ ^SYNC_SERVER_PATH(.*) {
+            client_max_body_size 0;
+            proxy_read_timeout 36000s;
+            proxy_pass http://127.0.0.1:8081/$1$is_args$args;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Cookie $http_cookie;
+        }
+    }
+}
+EOT
+
+sed -ri "s|APP|$APP|g; s|SYNC_SERVER_PATH|$SYNC_SERVER_PATH|g" $APP/nginx.conf
+EOF
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ COPY --chown=prompta:prompta . .
 # Make client app's default sync-server URI relative to URI on which it's hosted
 RUN sed -r -i.bak "s|return.*https://prompta-production.up.railway.app.*$|return window.location.href.replace(/(https?:\\\/\\\/[^\\\/]+)(\\\/.*)?$/, \"\$1$SYNC_SERVER_PATH\");|" src/lib/sync/vlcn.ts
 
-# Disable telemetry
-RUN [ "$TELEMETRY" = 0 ] && sed -r -i.bak 's!(cap\(|window.posthog.capture\()!return; // &!' src/lib/capture.ts
+# Optionally disable telemetry
+RUN if [ "$TELEMETRY" = "0" ]; then sed -r -i.bak 's!(cap\(|window.posthog.capture\()!return; // &!' src/lib/capture.ts; fi
 
 # # Use Bun instead of PNPM for package management
 RUN bun install --frozen-lockfile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY . .
 
 # Use Bun instead of PNPM for package management
 RUN bun install --frozen-lockfile
+RUN bun pm trust --all
 RUN bun run build:server
 
 FROM node:20-slim as dist


### PR DESCRIPTION
This updated Dockerfile builds a fully integrated Prompta client/server app, which is both useful and (I believe) provides a much better initial experience of Prompta for new users.

This Dockerfile:

- Builds a local sync server
- Builds static client app, patched to reference the local sync server URI
- Configures an nginx server to serve the client app, and to reverse-proxy requests from /db/ to the sync server
- Runs the s6 supervisor as entrypoint to launch and keep the sync server and nginx running
- Uses bun as per the latest upstream Dockerfile
- Is an updated version of the Dockerfile referred to at https://github.com/iansinnott/prompta/pull/48

Tastes obviously vary with respect to Dockerfile formatting, structuring, on generation of needed files inline (as here) vs including each file separately in the repo, and on whether the resulting build should be a development or minimised production build, so initial assumptions were made for this implementation, but all can easily be changed to accomodate author's preferences.
